### PR TITLE
Update colorpicker-propicker

### DIFF
--- a/Casks/colorpicker-propicker.rb
+++ b/Casks/colorpicker-propicker.rb
@@ -1,11 +1,10 @@
 cask 'colorpicker-propicker' do
   version '1.0'
-  sha256 'd1c07c116fee22dbbaea86c285327b5468b82863ba575e8fe462a2dcec023891'
+  sha256 'f5d99b75e74005f7899cb47a0098c112fb43ef7e5a11b1e947c2db3566be8716'
 
-  url "https://www.irradiated.net/appcasts/pro-picker/releases/#{version}/ProPicker.zip"
-  appcast 'https://www.irradiated.net/pages/blank/release-notes.php?app=pro-picker'
+  url 'https://irradiated.net/files/pro-picker.zip'
   name 'Pro Picker'
-  homepage 'https://www.irradiated.net/?page=pro-picker'
+  homepage 'https://irradiated.net/tool/pro-picker/'
 
   colorpicker 'ProPicker.colorPicker'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Developer switched his website to GitHub Pages, and that broke the Homebrew Cask download URL. Unfortunately, no appcast as of yet. I'll reach out to him.